### PR TITLE
Optimise. Pythonise. Bug fix x2.

### DIFF
--- a/nsrecruit/ns_recruit_pure.py
+++ b/nsrecruit/ns_recruit_pure.py
@@ -15,24 +15,36 @@ def nope(nation):
 async def recruit(channel):
     """Gives a list of up to 8 nations to send recruitment telegrams"""
 
-    h = await nsapi("happenings", limit=str(), filter='founding')
+    h = await nsapi("happenings", limit=str(15+len(done)*15), filter='founding')
     events = x2d.parse(pretty_string(h))["WORLD"]["HAPPENINGS"]["EVENT"]
 
     nations, e_iter = list(), events.__iter__()
     new = lambda: e_iter.__next__()['TEXT'].split("@@")[1]
     nation = new()
     for n in range(8):
-        while nope(nation): nation = new()
+        try:
+            while nope(nation): nation = new()
+        except (StopIteration, RuntimeError): break
         (done.append(nation), nations.append(nation))
-    print(nations)
+    assert nations
     return await channel.send(', '.join(nations))
 
 @client.event
 async def on_ready():print('running.')
+async def review(channel, e):
+    e.title, d_iter = "Run out of noobs.", done.__iter__()
+    for i in range(len(done)//8+1):
+      try:
+        e.add_field(name=str(i+1), value=', '.join([d_iter.__next__()for _ in range(8)]), inline=True)
+      except StopIteration:
+        e.add_field(name=str(len(done)//8+1), value=', '.join(done[-(len(done)%8):]), inline=True)
+    await channel.send(embed=e)
 
 @client.event
 async def on_message(message):
   if message.content.startswith('!'):
     if message.content[1:].startswith("recruit"):
-      await recruit(message.channel)
+      try: await recruit(message.channel)
+      except:
+          await review(message.channel, __import__('discord').Embed(color=0xff6600))
     else: print(message.content[1:], 'is not a command')

--- a/nsrecruit/ns_recruit_pure.py
+++ b/nsrecruit/ns_recruit_pure.py
@@ -1,0 +1,38 @@
+from sans.api import Api as nsapi
+from sans.utils import pretty_string
+import xmltodict as x2d
+client=__import__('discord').Client()
+nsapi.agent = "CAESAR, by Artevenia"
+
+done = []
+def nope(nation):
+    if any([t.isdigit()for t in nation]) or nation in done:
+          return 1
+    if not nation or nation.__class__.__name__ == 'OrderedDict':
+          return 2
+    else: return 0
+
+async def recruit(channel):
+    """Gives a list of up to 8 nations to send recruitment telegrams"""
+
+    h = await nsapi("happenings", limit=str(), filter='founding')
+    events = x2d.parse(pretty_string(h))["WORLD"]["HAPPENINGS"]["EVENT"]
+
+    nations, e_iter = list(), events.__iter__()
+    new = lambda: e_iter.__next__()['TEXT'].split("@@")[1]
+    nation = new()
+    for n in range(8):
+        while nope(nation): nation = new()
+        (done.append(nation), nations.append(nation))
+    print(nations)
+    return await channel.send(', '.join(nations))
+
+@client.event
+async def on_ready():print('running.')
+
+@client.event
+async def on_message(message):
+  if message.content.startswith('!'):
+    if message.content[1:].startswith("recruit"):
+      await recruit(message.channel)
+    else: print(message.content[1:], 'is not a command')

--- a/nsrecruit/ns_recruit_pure.py
+++ b/nsrecruit/ns_recruit_pure.py
@@ -37,7 +37,7 @@ async def review(channel, e):
       try:
         e.add_field(name=str(i+1), value=', '.join([d_iter.__next__()for _ in range(8)]), inline=False)
       except StopIteration:
-        e.add_field(name=str(len(done)//8+1), value=', '.join(done[-(len(done)%8):]), inline=False)
+        len(done)%8 and e.add_field(name=str(len(done)//8+1), value=', '.join(done[-(len(done)%8):]), inline=False)
     await channel.send(embed=e)
 
 @client.event
@@ -46,5 +46,5 @@ async def on_message(message):
     if message.content[1:].startswith("recruit"):
       try: await recruit(message.channel)
       except:
-          await review(message.channel, __import__('discord').Embed(color=0xff6600))
+          await review(message.channel, __import__('discord').Embed(color=0x506075))
     else: print(message.content[1:], 'is not a command')

--- a/nsrecruit/ns_recruit_pure.py
+++ b/nsrecruit/ns_recruit_pure.py
@@ -35,9 +35,9 @@ async def review(channel, e):
     e.title, d_iter = "Run out of noobs.", done.__iter__()
     for i in range(len(done)//8+1):
       try:
-        e.add_field(name=str(i+1), value=', '.join([d_iter.__next__()for _ in range(8)]), inline=True)
+        e.add_field(name=str(i+1), value=', '.join([d_iter.__next__()for _ in range(8)]), inline=False)
       except StopIteration:
-        e.add_field(name=str(len(done)//8+1), value=', '.join(done[-(len(done)%8):]), inline=True)
+        e.add_field(name=str(len(done)//8+1), value=', '.join(done[-(len(done)%8):]), inline=False)
     await channel.send(embed=e)
 
 @client.event


### PR DESCRIPTION
Courtesy of the Dalek Empire.

#bug fixes
 - removed trailing comma, joined list of nations by comma at the end rather than appending comma to each name
 - disallowed repeats, which can be reset by resetting the bot.

#readability and runtime
* reduce counter to for loop, reduce event for loop to while loop using rejection method and iteration dunders.
* shorten variable names in long lines as the mouse only scrolls vertically.
* remove middle-man variables, to optimise the namespace.
* redistribute blank lines, make class methods rather than local functions.
* replace regex overkill with python builtins.